### PR TITLE
feat: add countdown service layer with tests

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -11,22 +11,15 @@
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
-import axios from 'axios'
 import CountdownForm from './components/CountdownForm.vue'
 import CountdownList from './components/CountdownList.vue'
-
-interface Countdown {
-  id: string
-  title: string
-  expiresAt: string
-}
+import { listCountdowns, type Countdown } from './services/countdowns'
 
 const countdowns = ref<Countdown[]>([])
 
 async function loadCountdowns() {
   try {
-    const res = await axios.get('/api/countdowns')
-    countdowns.value = res.data
+    countdowns.value = await listCountdowns()
   } catch (err) {
     console.error(err)
   }

--- a/frontend/src/components/CountdownForm.vue
+++ b/frontend/src/components/CountdownForm.vue
@@ -1,27 +1,27 @@
 <template>
   <form @submit.prevent="submit">
     <input v-model="title" placeholder="Title" />
-    <input v-model="expiresAt" type="datetime-local" />
+    <input v-model="expiration" type="datetime-local" />
     <button type="submit">Create</button>
   </form>
 </template>
 
 <script setup lang="ts">
 import { ref } from 'vue'
-import axios from 'axios'
+import { createCountdown } from '../services/countdowns'
 
 const emit = defineEmits<{ (e: 'created'): void }>()
 const title = ref('')
-const expiresAt = ref('')
+const expiration = ref('')
 
 async function submit() {
-  if (!title.value || !expiresAt.value) return
-  await axios.post('/api/countdowns', {
+  if (!title.value || !expiration.value) return
+  await createCountdown({
     title: title.value,
-    expiresAt: expiresAt.value
+    expiration: expiration.value
   })
   title.value = ''
-  expiresAt.value = ''
+  expiration.value = ''
   emit('created')
 }
 </script>

--- a/frontend/src/components/CountdownList.vue
+++ b/frontend/src/components/CountdownList.vue
@@ -1,11 +1,11 @@
 <template>
   <ul>
     <li v-for="item in items" :key="item.id">
-      {{ item.title }} - {{ new Date(item.expiresAt).toLocaleString() }}
+      {{ item.title }} - {{ new Date(item.expiration).toLocaleString() }}
     </li>
   </ul>
 </template>
 
 <script setup lang="ts">
-defineProps<{ items: { id: string; title: string; expiresAt: string }[] }>()
+defineProps<{ items: { id: string; title: string; expiration: string }[] }>()
 </script>

--- a/frontend/src/components/__tests__/CountdownForm.spec.ts
+++ b/frontend/src/components/__tests__/CountdownForm.spec.ts
@@ -1,0 +1,20 @@
+/* @vitest-environment jsdom */
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, vi } from 'vitest'
+import CountdownForm from '../CountdownForm.vue'
+import * as service from '../../services/countdowns'
+
+describe('CountdownForm', () => {
+  it('submits new countdown', async () => {
+    const mock = vi.spyOn(service, 'createCountdown').mockResolvedValue({ id: '1', title: 'Demo', expiration: '2030-01-01' })
+    const wrapper = mount(CountdownForm)
+
+    await wrapper.find('input[placeholder="Title"]').setValue('Demo')
+    await wrapper.find('input[type="datetime-local"]').setValue('2030-01-01T00:00')
+
+    await wrapper.find('form').trigger('submit.prevent')
+
+    expect(mock).toHaveBeenCalledWith({ title: 'Demo', expiration: '2030-01-01T00:00' })
+    expect(wrapper.emitted()).toHaveProperty('created')
+  })
+})

--- a/frontend/src/components/__tests__/CountdownList.spec.ts
+++ b/frontend/src/components/__tests__/CountdownList.spec.ts
@@ -1,3 +1,4 @@
+/* @vitest-environment jsdom */
 import { mount } from '@vue/test-utils'
 import { describe, it, expect } from 'vitest'
 import CountdownList from '../CountdownList.vue'
@@ -5,7 +6,7 @@ import CountdownList from '../CountdownList.vue'
 describe('CountdownList', () => {
   it('renders items', () => {
     const wrapper = mount(CountdownList, {
-      props: { items: [{ id: '1', title: 'Test', expiresAt: '2030-01-01T00:00:00Z' }] }
+      props: { items: [{ id: '1', title: 'Test', expiration: '2030-01-01T00:00:00Z' }] }
     })
     expect(wrapper.text()).toContain('Test')
   })

--- a/frontend/src/services/__tests__/countdowns.spec.ts
+++ b/frontend/src/services/__tests__/countdowns.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}))
+
+import axios from 'axios'
+import { listCountdowns, createCountdown } from '../countdowns'
+
+const mockedAxios = axios as unknown as {
+  get: ReturnType<typeof vi.fn>
+  post: ReturnType<typeof vi.fn>
+}
+
+describe('countdown service', () => {
+  it('lists countdowns', async () => {
+    mockedAxios.get.mockResolvedValue({ data: [{ id: '1', title: 'Test', expiration: '2030-01-01' }] })
+    const result = await listCountdowns()
+    expect(mockedAxios.get).toHaveBeenCalledWith('/api/countdowns')
+    expect(result).toHaveLength(1)
+  })
+
+  it('creates countdown', async () => {
+    const input = { title: 'Demo', expiration: '2030-01-01' }
+    mockedAxios.post.mockResolvedValue({ data: { id: '2', ...input } })
+    const result = await createCountdown(input)
+    expect(mockedAxios.post).toHaveBeenCalledWith('/api/countdowns', input)
+    expect(result.id).toBe('2')
+  })
+})

--- a/frontend/src/services/countdowns.ts
+++ b/frontend/src/services/countdowns.ts
@@ -1,0 +1,23 @@
+import axios from 'axios'
+
+export interface Countdown {
+  id: string
+  title: string
+  expiration: string
+  createdAt?: string
+}
+
+export interface CountdownInput {
+  title: string
+  expiration: string
+}
+
+export async function listCountdowns(): Promise<Countdown[]> {
+  const res = await axios.get('/api/countdowns')
+  return res.data
+}
+
+export async function createCountdown(input: CountdownInput): Promise<Countdown> {
+  const res = await axios.post('/api/countdowns', input)
+  return res.data
+}

--- a/specs/frontend-backend-integration.md
+++ b/specs/frontend-backend-integration.md
@@ -1,0 +1,47 @@
+# Frontend/Backend Integration Spec
+
+## Overview
+The Countdown application consists of a Deno backend that exposes a REST API and a Vue frontend that consumes it.  This spec describes the integration points between the two layers and the tests required to validate them.
+
+## API
+The backend exposes the following endpoints:
+
+- `GET /api/countdowns` – returns an array of `Countdown` objects.
+- `POST /api/countdowns` – accepts a `CountdownInput` JSON payload and returns the created `Countdown`.
+
+### Data Types
+```ts
+interface CountdownInput {
+  title: string;
+  expiration: string; // ISO date
+}
+
+interface Countdown extends CountdownInput {
+  id: string;
+  createdAt: string;
+}
+```
+The frontend must use the `expiration` field name to match the backend.  Earlier versions used `expiresAt` which caused integration issues.
+
+## Frontend Service Layer
+Create a service module `src/services/countdowns.ts` that wraps the API calls.  It should provide:
+
+- `listCountdowns(): Promise<Countdown[]>` – calls `GET /api/countdowns`.
+- `createCountdown(input: CountdownInput): Promise<Countdown>` – posts to `POST /api/countdowns`.
+
+Components import these helpers instead of using `axios` directly.  This centralises API access and simplifies mocking in tests.
+
+## Components
+- `App.vue` fetches countdowns on mount via `listCountdowns()`.
+- `CountdownForm.vue` creates a countdown using `createCountdown()` and emits `created` when finished.
+- `CountdownList.vue` displays items, reading `item.expiration`.
+
+## Tests
+Use Vitest with `@vue/test-utils` and mocked modules.
+
+- **Service tests**: verify `listCountdowns()` and `createCountdown()` call the correct endpoints and return data.
+- **Component tests**:
+  - `CountdownForm.vue` submits data through the service and emits `created`.
+  - `CountdownList.vue` renders the passed in `expiration` values (existing test updated).
+
+These tests ensure the frontend correctly integrates with the backend API and will guard against regressions in contract or field names.


### PR DESCRIPTION
## Summary
- document frontend/backend integration and test strategy
- add countdown service module with create/list helpers
- update components to use service and validate via new unit tests

## Testing
- `deno test backend/main_test.ts` *(fails: command not found)*
- `curl -fsSL https://deno.land/install.sh | sh -s -- -q` *(fails: HTTP 403)*
- `cd frontend && npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a38e4a498c8321a9bc02bc4fd49f47