### PR TITLE
Add Hetzner deployment infrastructure and spec

### DIFF
--- a/cloud-init/hetzner.yaml
+++ b/cloud-init/hetzner.yaml
@@ -1,0 +1,56 @@
+#cloud-config
+package_update: true
+packages:
+  - podman
+
+write_files:
+  - path: /etc/systemd/system/countdowns-postgres.service
+    permissions: "0644"
+    content: |
+      [Unit]
+      Description=PostgreSQL container for countdowns
+      After=network-online.target
+
+      [Service]
+      ExecStart=/usr/bin/podman run --rm --name countdowns-postgres -e POSTGRES_DB=countdowns -e POSTGRES_USER=countdowns -e POSTGRES_PASSWORD=countdowns -v countdowns-pgdata:/var/lib/postgresql/data -p 5432:5432 docker.io/library/postgres:16-alpine
+      ExecStop=/usr/bin/podman stop countdowns-postgres
+      Restart=always
+
+      [Install]
+      WantedBy=multi-user.target
+
+  - path: /etc/systemd/system/countdowns-backend.service
+    permissions: "0644"
+    content: |
+      [Unit]
+      Description=Countdowns backend container
+      After=network-online.target
+
+      [Service]
+      ExecStart=/usr/bin/podman run --rm --name countdowns-backend -p 8000:8000 ghcr.io/countdowns/backend:latest
+      ExecStop=/usr/bin/podman stop countdowns-backend
+      Restart=always
+
+      [Install]
+      WantedBy=multi-user.target
+
+  - path: /etc/systemd/system/countdowns-frontend.service
+    permissions: "0644"
+    content: |
+      [Unit]
+      Description=Caddy front controller serving countdowns frontend
+      After=network-online.target
+
+      [Service]
+      ExecStart=/usr/bin/podman run --rm --name countdowns-frontend -p 80:80 -p 443:443 ghcr.io/countdowns/frontend:latest
+      ExecStop=/usr/bin/podman stop countdowns-frontend
+      Restart=always
+
+      [Install]
+      WantedBy=multi-user.target
+
+runcmd:
+  - systemctl daemon-reload
+  - systemctl enable --now countdowns-postgres.service
+  - systemctl enable --now countdowns-backend.service
+  - systemctl enable --now countdowns-frontend.service

--- a/containers/Caddyfile
+++ b/containers/Caddyfile
@@ -1,0 +1,10 @@
+:80 {
+  encode gzip
+  root * /usr/share/caddy
+  try_files {path} /index.html
+  file_server
+  @api {
+    path /api/*
+  }
+  reverse_proxy @api localhost:8000
+}

--- a/containers/backend/Containerfile
+++ b/containers/backend/Containerfile
@@ -1,0 +1,6 @@
+FROM docker.io/denoland/deno:alpine
+WORKDIR /app
+COPY backend/ .
+RUN deno cache main.ts
+EXPOSE 8000
+CMD ["deno", "run", "--allow-net", "--allow-env", "main.ts"]

--- a/containers/caddy/Containerfile
+++ b/containers/caddy/Containerfile
@@ -1,0 +1,13 @@
+# Build frontend assets
+FROM docker.io/library/node:18-alpine AS build
+WORKDIR /app
+COPY frontend/package*.json ./
+RUN npm ci
+COPY frontend/ .
+RUN npm run build
+
+# Serve with Caddy
+FROM docker.io/library/caddy:alpine
+COPY containers/Caddyfile /etc/caddy/Caddyfile
+COPY --from=build /app/dist /usr/share/caddy
+EXPOSE 80 443

--- a/containers/postgres.yml
+++ b/containers/postgres.yml
@@ -1,0 +1,13 @@
+services:
+  db:
+    image: docker.io/library/postgres:16-alpine
+    environment:
+      POSTGRES_DB: countdowns
+      POSTGRES_USER: countdowns
+      POSTGRES_PASSWORD: countdowns
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+volumes:
+  db-data:

--- a/specs/hetzner-deployment/RFC.md
+++ b/specs/hetzner-deployment/RFC.md
@@ -1,0 +1,37 @@
+# Hetzner Deployment RFC
+
+## Objective
+Deploy the Countdown application on a Hetzner Cloud server using Podman containers managed by systemd with Caddy as the front controller.
+
+## Components
+- **Container images**
+  - `backend`: Deno API exposing countdown endpoints.
+  - `frontend`: Caddy image serving the built Vue app and proxying `/api` to the backend.
+  - `postgres`: Official Postgres image for persistence.
+- **Systemd units** run each container with Podman.
+- **Terraform** provisions the Hetzner server and feeds it cloud-init user data.
+- **Cloud-init** installs Podman and writes the systemd unit files before enabling them.
+
+## Trade-offs
+- Single-server architecture keeps costs and complexity low but offers no high availability.
+- Embedding service definitions in cloud-init simplifies bootstrap but couples OS image and application rollout.
+- Running Postgres in a container eases setup yet lacks managed backups.
+
+## Open Questions
+- What domain name and TLS certificate approach should Caddy use?
+- Which container registry will host the built images?
+- Should the database run on the same host or use an external service?
+- How will secrets (DB password, API keys) be provided securely?
+- What server size and region best meet expected load and latency requirements?
+
+## Decisions Needed
+- Confirm Hetzner server type and location.
+- Define container registry and CI pipeline for publishing images.
+- Establish DNS and TLS strategy.
+- Choose a backup approach for persistent volumes.
+- Provide required environment variables for the services.
+
+## Testability
+- `terraform plan` produces expected infrastructure changes.
+- Cloud-init bootstraps Podman and starts all systemd services.
+- Accessing the server over HTTP serves the Vue app and proxies API requests to the backend.

--- a/systemd/countdowns-backend.service
+++ b/systemd/countdowns-backend.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Countdowns backend container
+After=network-online.target
+
+[Service]
+ExecStart=/usr/bin/podman run --rm --name countdowns-backend -p 8000:8000 ghcr.io/countdowns/backend:latest
+ExecStop=/usr/bin/podman stop countdowns-backend
+Restart=always
+
+[Install]
+WantedBy=default.target

--- a/systemd/countdowns-frontend.service
+++ b/systemd/countdowns-frontend.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Caddy front controller serving countdowns frontend
+After=network-online.target
+
+[Service]
+ExecStart=/usr/bin/podman run --rm --name countdowns-frontend -p 80:80 -p 443:443 ghcr.io/countdowns/frontend:latest
+ExecStop=/usr/bin/podman stop countdowns-frontend
+Restart=always
+
+[Install]
+WantedBy=default.target

--- a/systemd/countdowns-postgres.service
+++ b/systemd/countdowns-postgres.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=PostgreSQL container for countdowns
+After=network-online.target
+
+[Service]
+ExecStart=/usr/bin/podman run --rm --name countdowns-postgres -e POSTGRES_DB=countdowns -e POSTGRES_USER=countdowns -e POSTGRES_PASSWORD=countdowns -v countdowns-pgdata:/var/lib/postgresql/data -p 5432:5432 docker.io/library/postgres:16-alpine
+ExecStop=/usr/bin/podman stop countdowns-postgres
+Restart=always
+
+[Install]
+WantedBy=default.target

--- a/terraform/hetzner/main.tf
+++ b/terraform/hetzner/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = "~> 1.44"
+    }
+  }
+}
+
+provider "hcloud" {
+  token = var.hcloud_token
+}
+
+resource "hcloud_server" "countdowns" {
+  name        = "countdowns"
+  image       = "ubuntu-22.04"
+  server_type = "cx11"
+  location    = "nbg1"
+  user_data   = file("${path.module}/../../cloud-init/hetzner.yaml")
+}

--- a/terraform/hetzner/variables.tf
+++ b/terraform/hetzner/variables.tf
@@ -1,0 +1,4 @@
+variable "hcloud_token" {
+  description = "API token for Hetzner Cloud"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- document Hetzner Cloud rollout with Podman, systemd, and Caddy
- add container definitions for backend, frontend (Caddy), and Postgres
- include Terraform config and cloud-init to provision and bootstrap a Hetzner server

## Testing
- `terraform fmt terraform/hetzner/main.tf terraform/hetzner/variables.tf` *(fails: command not found)*
- `make test` *(fails: deno: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a39e38ed6c8321bc0a4f1186465904